### PR TITLE
Allow disabling watch mode for tests

### DIFF
--- a/src/tasks/test.ts
+++ b/src/tasks/test.ts
@@ -13,15 +13,6 @@ task(TASK_TEST)
   )
   .setAction(async (args: TestArgs, hre, runSuper) => {
     if (!args.watch) {
-      if (args.only !== "" || args.except !== "") {
-        console.error(
-          chalk.red.bold(
-            "flags: only, except are only to be used along with --watch",
-          ),
-        );
-        return;
-      }
-
       await runSuper();
       return;
     }

--- a/src/tasks/test.ts
+++ b/src/tasks/test.ts
@@ -12,6 +12,21 @@ task(TASK_TEST)
     "Watch changes in files used in test (from testDir of config)",
   )
   .setAction(async (args: TestArgs, hre, runSuper) => {
+    if (!args.watch) {
+      if (args.only !== "" || args.except !== "") {
+        console.error(
+          chalk.red.bold(
+            "flags: only, except are only to be used along with --watch",
+          ),
+        );
+        return;
+      }
+
+      await runSuper();
+      return;
+    }
+
+
     const testFiles = args.testFiles;
     const {testDir, compileDir} = hre.config.compileWatch;
 


### PR DESCRIPTION
Not sure which way it's better to accomplish, but I need to be able to disable watch mode to run tests on CI